### PR TITLE
fix: 修复h5快速来回切换tabBar,在资源未加载出来的情况下页面重复#11583

### DIFF
--- a/packages/taro-router/src/router/page.ts
+++ b/packages/taro-router/src/router/page.ts
@@ -133,8 +133,11 @@ export default class PageHandler {
       container.appendChild(panel)
 
       document.body.appendChild(container)
-
-      initTabbar(this.config)
+      document.onreadystatechange = () => {
+        if(document.readyState == 'complete') {
+          initTabbar(this.config)
+        }
+      }
     } else {
       document.body.appendChild(app)
     }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

tabbar先于静态页面渲染，提前切换导致页面重复

**这个 PR 是什么类型?** (至少选择一个)

- [√] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [√] Web 平台（H5）
- [ ] 移动端（React-Native）
